### PR TITLE
feat: Rename storage env

### DIFF
--- a/fast_clean/settings.py
+++ b/fast_clean/settings.py
@@ -61,8 +61,9 @@ class CoreS3SettingsSchema(BaseModel):
     """
 
     endpoint: str
-    aws_access_key_id: str
-    aws_secret_access_key: str
+    endpoint_url: str
+    access_key_id: str
+    secret_access_key: str
     port: int
     bucket: str
     secure: bool = False


### PR DESCRIPTION
Variables from fastapi-boilreplate have been removed.

aws has been removed as a reference to a specific implementation.